### PR TITLE
Cleanup

### DIFF
--- a/ProfileAnalyzer.cs
+++ b/ProfileAnalyzer.cs
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Protobuf;
-using pb = Perftools.Profiles;
-
-using Microsoft.Windows.EventTracing;
-using Microsoft.Windows.EventTracing.Cpu;
-using Microsoft.Windows.EventTracing.Symbols;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -26,6 +19,11 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Google.Protobuf;
+using Microsoft.Windows.EventTracing;
+using Microsoft.Windows.EventTracing.Cpu;
+using Microsoft.Windows.EventTracing.Symbols;
+using pb = Perftools.Profiles;
 
 namespace IdleWakeups
 {
@@ -34,99 +32,13 @@ namespace IdleWakeups
     public struct Options
     {
       public string EtlFileName { get; set; }
+      public bool IncludeProcessIds { get; set; }
+      public bool IncludeProcessAndThreadIds { get; set; }
       public decimal TimeStart { get; set; }
       public decimal TimeEnd { get; set; }
       public HashSet<string> ProcessFilterSet { get; set; }
       public bool Tabbed { get; set; }
       public bool Verbose { get; set; }
-    }
-
-    private struct IdleWakeup
-    {
-      public long ContextSwitchCount { get; set; }
-      public long ContextSwitchDPCCount { get; set; }
-      public int ProcessId { get; set; }
-      public string ProcessName { get; set; }
-      public ChromeProcessType ProcessType { get; set; }
-      public string ThreadName { get; set; }
-      public Dictionary<string, StackFrames> ReadyingThreadStacks { get; set; }
-      public Dictionary<string, StackFrames> ReadiedThreadStacks { get; set; }
-    }
-
-    private struct ChromeProcessType
-    {
-      public ChromeProcessType(string type, string? subType)
-      {
-        Type = type;
-        SubType = subType;
-      }
-      public string Type { get; set; }
-
-      public string? SubType { get; set; }
-    }
-
-    private struct StackFrames
-    {
-      public long StackCount { get; set; }
-      public long StackDPCCount { get; set; }
-      public IReadOnlyList<StackFrame> Stack { get; set; }
-    }
-
-    readonly struct Location
-    {
-      public Location(int processId, string imagePath, Address? functionAddress, string functionName)
-      {
-        ProcessId = processId;
-        ImagePath = imagePath;
-        FunctionAddress = functionAddress;
-        FunctionName = functionName;
-      }
-      int ProcessId { get; }
-      string ImagePath { get; }
-      Address? FunctionAddress { get; }
-      string FunctionName { get; }
-
-      public override bool Equals(object? other)
-      {
-        return other is Location location &&
-               ProcessId == location.ProcessId &&
-               ImagePath == location.ImagePath &&
-               EqualityComparer<Address?>.Default.Equals(FunctionAddress, location.FunctionAddress) &&
-               FunctionName == location.FunctionName;
-      }
-
-      public override int GetHashCode()
-      {
-        return HashCode.Combine(ProcessId, ImagePath, FunctionAddress, FunctionName);
-      }
-    }
-
-    readonly struct Function
-    {
-      public Function(string imageName, string functionName)
-      {
-        ImageName = imageName;
-        FunctionName = functionName;
-      }
-      string ImageName { get; }
-      string FunctionName { get; }
-
-      public override bool Equals(object? other)
-      {
-        return other is Function function &&
-               ImageName == function.ImageName &&
-               FunctionName == function.FunctionName;
-      }
-
-      public override int GetHashCode()
-      {
-        return HashCode.Combine(ImageName, FunctionName);
-      }
-
-      public override string ToString()
-      {
-        return String.Format("{0}!{1}", ImageName, FunctionName);
-      }
     }
 
     public ProfileAnalyzer(Options options)
@@ -149,42 +61,45 @@ namespace IdleWakeups
       _functions = new Dictionary<Function, ulong>();
       _nextFunctionId = 1;
 
-      // Counts all readied callstacks related to idlewakeups where a context switch between an
-      // (old) idle thread and (new) thread in e.g. Chrome has taken place.
+      // When a thread is off-CPU sleeping, it is eventually woken up. This is performed by
+      // another thread, the waker thread.
+
+      // Counts all callstacks for woken threads related to idlewakeups where a context switch
+      // between an (old) idle thread and (new) thread in e.g. Chrome has taken place.
       var iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readied_all");
+      iWakeupCountValueType.Type = GetStringId("woken_all");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
 
-      // Counts all readied callstacks where the readying thread was not doing DPC.
+      // Counts all woken callstacks where the waker thread was not doing DPC.
       iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readied_no_dpc");
+      iWakeupCountValueType.Type = GetStringId("woken_no_dpc");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
 
-      // Counts all readied callstacks where the readying thread was doing DPC.
+      // Counts all woken callstacks where the waker thread was doing DPC.
       iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readied_dpc");
+      iWakeupCountValueType.Type = GetStringId("woken_dpc");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
 
-      // Counts all readying callstacks related to idlewakeups where a context switch between an
-      // (old) idle thread and (new) thread in e.g. Chrome has taken place. These callstacks comes
-      // from the readying thread that made the new thread eligible to run.
+      // Counts all callstacks for waker threads related to idlewakeups where a context switch
+      // between an (old) idle thread and (new) thread in e.g. Chrome has taken place. These
+      // callstacks comes from the readying thread that made the new thread eligible to run.
       iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readying_all");
+      iWakeupCountValueType.Type = GetStringId("waker_all");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
 
-      // Counts all readying callstacks where the readying thread was not doing DPC.
+      // Counts all waker callstacks where the waker thread was not doing DPC.
       iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readying_no_dpc");
+      iWakeupCountValueType.Type = GetStringId("waker_no_dpc");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
 
-      // Counts all readying callstacks where the readying thread was not doing DPC.
+      // Counts all waker callstacks where the waker thread was not doing DPC.
       iWakeupCountValueType = new pb.ValueType();
-      iWakeupCountValueType.Type = GetStringId("readying_dpc");
+      iWakeupCountValueType.Type = GetStringId("waker_dpc");
       iWakeupCountValueType.Unit = GetStringId("count");
       _profile.SampleType.Add(iWakeupCountValueType);
     }
@@ -335,37 +250,6 @@ namespace IdleWakeups
             cStateCount += 1;
             _previousCStates[prevCState.Value] = cStateCount;
           }
-
-          // Finally, store the two stacks (readied/new and readying) once again but this time as
-          // separate dictionaries (not as part of IdleWakeup) with thread ID as key. Instead, use
-          // the unique strings from GetAnalyzerString() as keys and map count and list of stack
-          // frames as value. This will give us the full/true distibution of callstacks since the
-          // one stored with thread ID may contain copies of the same stack frames.
-          // These two dictionaries will be used as base for exporting callstacks to pprof profiles.
-          if (readiedThreadStackKey != null && readiedThreadStackFrames != null)
-          {
-            _readiedThreadStacksByAnalyzerString.TryGetValue(readiedThreadStackKey, out stackFrames);
-            stackFrames.StackCount++;
-            if (readyingThreadInDPC)
-            {
-              stackFrames.StackDPCCount++;
-            }
-            stackFrames.Stack = readiedThreadStackFrames;
-            _readiedThreadStacksByAnalyzerString[readiedThreadStackKey] = stackFrames;
-          }
-
-          if (readyingThreadStackKey != null && readyingThreadStackFrames != null)
-          {
-            _readyingThreadStacksByAnalyzerString.TryGetValue(readyingThreadStackKey, out stackFrames);
-            stackFrames.StackCount++;
-            if (readyingThreadInDPC)
-            {
-              stackFrames.StackDPCCount++;
-            }
-            stackFrames.Stack = readyingThreadStackFrames;
-            _readyingThreadStacksByAnalyzerString[readyingThreadStackKey] = stackFrames;
-          }
-
         }  // if (switchOutImageName == "Idle")
       }
     }
@@ -443,7 +327,7 @@ namespace IdleWakeups
       Console.WriteLine();
 
       composite = "{0,6}{1}{2,6}{3}{4,-12}{5}{6,-12}{7}{8,-20}{9}{10,-55}{11}{12,6}{13}" +
-                  "{14,9}{15}{16,6}{17}{18,7:F}{19}{20,7}{21}{22,14}{23}{24,15}";
+                  "{14,9}{15}{16,6}{17}{18,7:F}{19}{20,7}{21}{22,12}{23}{24,12}";
       header = string.Format(composite,
         "TID", sep,
         "PID", sep,
@@ -456,8 +340,8 @@ namespace IdleWakeups
         "DPC", sep,
         "DPC (%)", sep,
         "DPC/sec", sep,
-        "Readied Stacks", sep,
-        "Readying Stacks");
+        "Woken Stacks", sep,
+        "Waker Stacks");
       Console.WriteLine(header);
       WriteHeaderLine(header.Length + 1);
 
@@ -529,90 +413,75 @@ namespace IdleWakeups
         _profile.Comment.Add(GetStringId("No samples exported"));
       }
 
-      // Write callstacks related to readiead threads.
-      var sortedReadiedThreadStacksByAnalyzerString =
-           new List<KeyValuePair<string, StackFrames>>(_readiedThreadStacksByAnalyzerString);
-      sortedReadiedThreadStacksByAnalyzerString.Sort((x, y) => y.Value.StackCount.CompareTo(x.Value.StackCount));
-      foreach (KeyValuePair<string, StackFrames> kvp in sortedReadiedThreadStacksByAnalyzerString)
+      foreach (var idleWakeup in _idleWakeupsByThreadId.Values)
       {
-        var sampleProto = new pb.Sample();
-        // Count three different types of readied threads: all, without DPC and with DPC.
-        sampleProto.Value.Add(kvp.Value.StackCount);
-        sampleProto.Value.Add(kvp.Value.StackCount - kvp.Value.StackDPCCount);
-        sampleProto.Value.Add(kvp.Value.StackDPCCount);
-        // Readying stack counts are all set to zero.
-        sampleProto.Value.Add(0);
-        sampleProto.Value.Add(0);
-        sampleProto.Value.Add(0);
-
-        var stackFrames = kvp.Value.Stack;
-
-        if (stackFrames.Count == 0)
+        // Write callstacks related to all woken threads.
+        var readiedThreadStacks = idleWakeup.ReadiedThreadStacks;
+        foreach (var stack in readiedThreadStacks.Values)
         {
-          continue;
+          var sampleProto = new pb.Sample();
+          sampleProto.Value.Add(stack.StackCount);
+          sampleProto.Value.Add(stack.StackCount - stack.StackDPCCount);
+          sampleProto.Value.Add(stack.StackDPCCount);
+          sampleProto.Value.Add(0);
+          sampleProto.Value.Add(0);
+          sampleProto.Value.Add(0);
+          var stackFrames = stack.Stack;
+          if (stackFrames.Count == 0)
+            continue;
+
+          foreach (var stackFrame in stackFrames)
+          {
+            if (stackFrame.HasValue && stackFrame.Symbol != null)
+            {
+              sampleProto.LocationId.Add(GetLocationId(stackFrame.Symbol));
+            }
+            else
+            {
+              // TODO(henrika): add support for "real PID" from Process.Id.
+              int processId = 0;
+              string imageName = stackFrame.Image?.FileName ?? "<unknown>";
+              string functionLabel = "<unknown>";
+              sampleProto.LocationId.Add(
+                GetPseudoLocationId(processId, imageName, null, functionLabel));
+            }
+          }
+          _profile.Sample.Add(sampleProto);
         }
 
-        foreach (var stackFrame in stackFrames)
+        // Write callstacks related to all waker threads (did the wakeup).
+        var readyingThreadStacks = idleWakeup.ReadyingThreadStacks;
+        foreach (var stack in readyingThreadStacks.Values)
         {
-          if (stackFrame.HasValue && stackFrame.Symbol != null)
+          var sampleProto = new pb.Sample();
+          sampleProto.Value.Add(0);
+          sampleProto.Value.Add(0);
+          sampleProto.Value.Add(0);
+          sampleProto.Value.Add(stack.StackCount);
+          sampleProto.Value.Add(stack.StackCount - stack.StackDPCCount);
+          sampleProto.Value.Add(stack.StackDPCCount);
+          var stackFrames = stack.Stack;
+          if (stackFrames.Count == 0)
+            continue;
+
+          foreach (var stackFrame in stackFrames)
           {
-            sampleProto.LocationId.Add(GetLocationId(stackFrame.Symbol));
+            if (stackFrame.HasValue && stackFrame.Symbol != null)
+            {
+              sampleProto.LocationId.Add(GetLocationId(stackFrame.Symbol));
+            }
+            else
+            {
+              // TODO(henrika): add support for "real PID" from Process.Id.
+              int processId = 0;
+              string imageName = stackFrame.Image?.FileName ?? "<unknown>";
+              string functionLabel = "<unknown>";
+              sampleProto.LocationId.Add(
+                GetPseudoLocationId(processId, imageName, null, functionLabel));
+            }
           }
-          else
-          {
-            // TODO(henrika): add support for "real PID" from Process.Id.
-            int processId = 0;
-            string imageName = stackFrame.Image?.FileName ?? "<unknown>";
-            string functionLabel = "<unknown>";
-            sampleProto.LocationId.Add(
-              GetPseudoLocationId(processId, imageName, null, functionLabel));
-          }
+          _profile.Sample.Add(sampleProto);
         }
-
-        _profile.Sample.Add(sampleProto);
-      }
-
-      // Write callstacks related to readying threads.
-      var sortedReadyingThreadStacksByAnalyzerString =
-          new List<KeyValuePair<string, StackFrames>>(_readyingThreadStacksByAnalyzerString);
-      sortedReadyingThreadStacksByAnalyzerString.Sort((x, y) => y.Value.StackCount.CompareTo(x.Value.StackCount));
-      foreach (KeyValuePair<string, StackFrames> kvp in sortedReadyingThreadStacksByAnalyzerString)
-      {
-        var sampleProto = new pb.Sample();
-        // Readied stack counts are all set to zero.
-        sampleProto.Value.Add(0);
-        sampleProto.Value.Add(0);
-        sampleProto.Value.Add(0);
-        // Count three different types of readying threads: all, without DPC and with DPC.
-        sampleProto.Value.Add(kvp.Value.StackCount);
-        sampleProto.Value.Add(kvp.Value.StackCount - kvp.Value.StackDPCCount);
-        sampleProto.Value.Add(kvp.Value.StackDPCCount);
-
-        var stackFrames = kvp.Value.Stack;
-
-        if (stackFrames.Count == 0)
-        {
-          continue;
-        }
-
-        foreach (var stackFrame in stackFrames)
-        {
-          if (stackFrame.HasValue && stackFrame.Symbol != null)
-          {
-            sampleProto.LocationId.Add(GetLocationId(stackFrame.Symbol));
-          }
-          else
-          {
-            // TODO(henrika): add support for "real PID" from Process.Id.
-            int processId = 0;
-            string imageName = stackFrame.Image?.FileName ?? "<unknown>";
-            string functionLabel = "<unknown>";
-            sampleProto.LocationId.Add(
-              GetPseudoLocationId(processId, imageName, null, functionLabel));
-          }
-        }
-
-        _profile.Sample.Add(sampleProto);
       }
 
       _profile.Comment.Add(
@@ -629,6 +498,190 @@ namespace IdleWakeups
           }
         }
       }
+    }
+
+    private struct IdleWakeup
+    {
+      public long ContextSwitchCount { get; set; }
+      public long ContextSwitchDPCCount { get; set; }
+      public int ProcessId { get; set; }
+      public string ProcessName { get; set; }
+      public ChromeProcessType ProcessType { get; set; }
+      public string ThreadName { get; set; }
+      public Dictionary<string, StackFrames> ReadyingThreadStacks { get; set; }
+      public Dictionary<string, StackFrames> ReadiedThreadStacks { get; set; }
+    }
+
+    private struct ChromeProcessType
+    {
+      public ChromeProcessType(string type, string? subType)
+      {
+        Type = type;
+        SubType = subType;
+      }
+      public string Type { get; set; }
+
+      public string? SubType { get; set; }
+    }
+
+    private struct StackFrames
+    {
+      public long StackCount { get; set; }
+      public long StackDPCCount { get; set; }
+      public IReadOnlyList<StackFrame> Stack { get; set; }
+    }
+
+    readonly struct Location
+    {
+      public Location(int processId, string imagePath, Address? functionAddress, string functionName)
+      {
+        ProcessId = processId;
+        ImagePath = imagePath;
+        FunctionAddress = functionAddress;
+        FunctionName = functionName;
+      }
+      int ProcessId { get; }
+      string ImagePath { get; }
+      Address? FunctionAddress { get; }
+      string FunctionName { get; }
+
+      public override bool Equals(object? other)
+      {
+        return other is Location location &&
+               ProcessId == location.ProcessId &&
+               ImagePath == location.ImagePath &&
+               EqualityComparer<Address?>.Default.Equals(FunctionAddress, location.FunctionAddress) &&
+               FunctionName == location.FunctionName;
+      }
+
+      public override int GetHashCode()
+      {
+        return HashCode.Combine(ProcessId, ImagePath, FunctionAddress, FunctionName);
+      }
+    }
+
+    readonly struct Function
+    {
+      public Function(string imageName, string functionName)
+      {
+        ImageName = imageName;
+        FunctionName = functionName;
+      }
+      string ImageName { get; }
+      string FunctionName { get; }
+
+      public override bool Equals(object? other)
+      {
+        return other is Function function &&
+               ImageName == function.ImageName &&
+               FunctionName == function.FunctionName;
+      }
+
+      public override int GetHashCode()
+      {
+        return HashCode.Combine(ImageName, FunctionName);
+      }
+
+      public override string ToString()
+      {
+        return String.Format("{0}!{1}", ImageName, FunctionName);
+      }
+    }
+
+    private ChromeProcessType GetChromeProcessType(string commandLine)
+    {
+      if (string.IsNullOrEmpty(commandLine))
+      {
+        return new ChromeProcessType("", "");
+      }
+
+      const string kProcessTypeParam = "--type=";
+      const string kRendererProcessType = "renderer";
+      const string kExtensionProcess = "extension";
+      const string kExtensionParam = "--extension-process";
+      const string kUtilityProcessType = "utility";
+      const string kUtilitySubTypeParam = "--utility-sub-type=";
+      const string kBrowserProcessType = "browser";
+      const string kChrashpadProcess = "crashpad-handler";
+      const string kChrashpadProcessShort = "crashpad";
+
+      string type = kBrowserProcessType;
+      string? subtype = null;
+
+      var commandLineSplit = commandLine.Split();
+      foreach (var commandLineArg in commandLineSplit)
+      {
+        if (commandLineArg.StartsWith(kProcessTypeParam))
+        {
+          type = commandLineArg[kProcessTypeParam.Length..];
+          if (type == kChrashpadProcess)
+          {
+            type = kChrashpadProcessShort;
+          }
+          else if (type == kRendererProcessType && commandLine.Contains(kExtensionParam))
+          {
+            type = kExtensionProcess;
+          }
+          else if (type == kUtilityProcessType)
+          {
+            var utilitySubType = commandLineSplit.First(s => s.StartsWith(kUtilitySubTypeParam));
+            if (utilitySubType != null)
+            {
+              // Example: 'video_capture.mojom.VideoCaptureService'.
+              subtype = utilitySubType[kUtilitySubTypeParam.Length..];
+              // Return only the last 'VideoCaptureService' part of this string.
+              var subs = subtype.Split('.');
+              subtype = subs[subs.Length - 1];
+              break;
+            }
+          }
+        }
+      }
+
+      return new ChromeProcessType(type, subtype);
+    }
+
+    private void WriteHeader(string header)
+    {
+      Console.ForegroundColor = ConsoleColor.Yellow;
+      Console.WriteLine(header);
+      Console.WriteLine();
+      Console.ForegroundColor = ConsoleColor.White;
+    }
+
+    private void WriteHeaderLine(int lenght)
+    {
+      StringBuilder sb = new StringBuilder();
+      if (!_options.Tabbed)
+      {
+        for (int i = 0; i < lenght; i++)
+        {
+          sb.Append("-");
+        }
+        Console.WriteLine(sb.ToString());
+      }
+    }
+
+    private void WriteVerbose(string message)
+    {
+      if (!_options.Verbose)
+        return;
+      Console.ForegroundColor = ConsoleColor.Green;
+      Console.WriteLine(message);
+      Console.ForegroundColor = ConsoleColor.White;
+    }
+
+    private string ProcessFilterToString()
+    {
+      StringBuilder sb = new StringBuilder();
+      if (_options.ProcessFilterSet == null)
+        return "*";
+      foreach (var item in _options.ProcessFilterSet)
+      {
+        sb.Append(item);
+        sb.Append(' ');
+      }
+      return sb.ToString().TrimEnd();
     }
 
     // string_table: All strings in the profile are represented as indices into this repeating
@@ -756,102 +809,6 @@ namespace IdleWakeups
       return functionId;
     }
 
-    private ChromeProcessType GetChromeProcessType(string commandLine)
-    {
-      if (string.IsNullOrEmpty(commandLine))
-      {
-        return new ChromeProcessType("", "");
-      }
-
-      const string kProcessTypeParam = "--type=";
-      const string kRendererProcessType = "renderer";
-      const string kExtensionProcess = "extension";
-      const string kExtensionParam = "--extension-process";
-      const string kUtilityProcessType = "utility";
-      const string kUtilitySubTypeParam = "--utility-sub-type=";
-      const string kBrowserProcessType = "browser";
-      const string kChrashpadProcess = "crashpad-handler";
-      const string kChrashpadProcessShort = "crashpad";
-
-      string type = kBrowserProcessType;
-      string? subtype = null;
-
-      var commandLineSplit = commandLine.Split();
-      foreach (var commandLineArg in commandLineSplit)
-      {
-        if (commandLineArg.StartsWith(kProcessTypeParam))
-        {
-          type = commandLineArg[kProcessTypeParam.Length..];
-          if (type == kChrashpadProcess)
-          {
-            type = kChrashpadProcessShort;
-          }
-          else if (type == kRendererProcessType && commandLine.Contains(kExtensionParam))
-          {
-            type = kExtensionProcess;
-          }
-          else if (type == kUtilityProcessType)
-          {
-            var utilitySubType = commandLineSplit.First(s => s.StartsWith(kUtilitySubTypeParam));
-            if (utilitySubType != null)
-            {
-              // Example: 'video_capture.mojom.VideoCaptureService'.
-              subtype = utilitySubType[kUtilitySubTypeParam.Length..];
-              // Return only the last 'VideoCaptureService' part of this string.
-              var subs = subtype.Split('.');
-              subtype = subs[subs.Length - 1];
-              break;
-            }
-          }
-        }
-      }
-
-      return new ChromeProcessType(type, subtype);
-    }
-
-    private void WriteHeader(string header)
-    {
-      Console.ForegroundColor = ConsoleColor.Yellow;
-      Console.WriteLine(header);
-      Console.WriteLine();
-      Console.ForegroundColor = ConsoleColor.White;
-    }
-
-    private void WriteHeaderLine(int lenght)
-    {
-      StringBuilder sb = new StringBuilder();
-      if (!_options.Tabbed)
-      {
-        for (int i = 0; i < lenght; i++)
-        {
-          sb.Append("-");
-        }
-        Console.WriteLine(sb.ToString());
-      }
-    }
-
-    private void WriteVerbose(string message)
-    {
-      if (!_options.Verbose)
-        return;
-      Console.ForegroundColor = ConsoleColor.Green;
-      Console.WriteLine(message);
-      Console.ForegroundColor = ConsoleColor.White;
-    }
-
-    private string ProcessFilterToString()
-    {
-      StringBuilder sb = new StringBuilder();
-      if (_options.ProcessFilterSet == null)
-        return "*";
-      foreach (var item in _options.ProcessFilterSet)
-      {
-        sb.Append(item);
-        sb.Append(' ');
-      }
-      return sb.ToString().TrimEnd();
-    }
-
     readonly Options _options;
 
     long _filteredProcessContextSwitch;
@@ -877,10 +834,6 @@ namespace IdleWakeups
     Dictionary<string, long> _filteredProcessReadyingProcesses = new Dictionary<string, long>();
 
     Dictionary<int, long> _previousCStates = new Dictionary<int, long>();
-
-    Dictionary<string, StackFrames> _readyingThreadStacksByAnalyzerString = new Dictionary<string, StackFrames>();
-
-    Dictionary<string, StackFrames> _readiedThreadStacksByAnalyzerString = new Dictionary<string, StackFrames>();
 
     pb.Profile _profile = new pb.Profile();
   }

--- a/Program.cs
+++ b/Program.cs
@@ -82,6 +82,14 @@ namespace IdleWakeups
               HelpText = "End of time range to analyze in seconds")]
       public decimal? timeEnd { get; set; }
 
+      [Option("includeProcessIds", Required = false, Default = false,
+              HelpText = "Whether process ids are included in the exported profile.")]
+      public bool includeProcessIds { get; set; }
+
+      [Option("includeProcessAndThreadIds", Required = false, Default = false,
+              HelpText = "Whether process and thread ids are included in the exported profile.")]
+      public bool includeProcessAndThreadIds { get; set; }
+
       [Option('s', "printSummary", Required = false, Default = false, SetName = "cpu",
               HelpText = "Whether a summary shall be written out after the analysis is completed.")]
       public bool printSummary { get; set; }
@@ -173,6 +181,8 @@ namespace IdleWakeups
 
         var profileOpts = new ProfileAnalyzer.Options();
         profileOpts.EtlFileName = opts.etlFileName;
+        profileOpts.IncludeProcessIds = opts.includeProcessIds;
+        profileOpts.IncludeProcessAndThreadIds = opts.includeProcessAndThreadIds;
         profileOpts.TimeStart = opts.timeStart ?? 0;
         profileOpts.TimeEnd = opts.timeEnd ?? decimal.MaxValue;
         profileOpts.Tabbed = opts.printTabbed;
@@ -201,6 +211,7 @@ namespace IdleWakeups
 
         long outputSize = profileAnalyzer.WritePprof(opts.outputFileName);
         Console.WriteLine("Wrote {0:N0} bytes to {1}", outputSize, opts.outputFileName);
+        Console.WriteLine();
 
         if (opts.verboseOutput)
         {


### PR DESCRIPTION
- Adds includeProcessIds and includeProcessAndThreadIds as command-line flags.
- Shifts dictionaries used when writing to pprof and use those which also stores the complete idle-wakeup state.
- Deletes _readyingThreadStacksByAnalyzerString and _readiedThreadStacksByAnalyzerString and add support for new pseudo locations given command-line flags.
