### PR TITLE
Added --includeWokenThreadIdsForWakers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,3 +124,4 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+csharp_indent_braces=false

--- a/Program.cs
+++ b/Program.cs
@@ -104,6 +104,10 @@ namespace IdleWakeups
               HelpText = "Includes process and thread ids in the exported profile.")]
       public bool includeProcessAndThreadIds { get; set; }
 
+      [Option("includeWokenThreadIdsForWakers", Required = false, Default = false, SetName = "pprof",
+             HelpText = "Adds ids of woken threads for wakers in the exported profile.")]
+      public bool includeWokenThreadIdsForWakers { get; set; }
+
       [Option("splitChromeProcesses", Required = false, Default = true, SetName = "pprof",
               HelpText = "Splits chrome.exe processes by type in the exported profile.")]
       public bool splitChromeProcesses { get; set; }
@@ -247,6 +251,7 @@ namespace IdleWakeups
         profileOpts.TimeEnd = opts.timeEnd ?? decimal.MaxValue;
         profileOpts.IncludeProcessIds = opts.includeProcessIds;
         profileOpts.IncludeProcessAndThreadIds = opts.includeProcessAndThreadIds;
+        profileOpts.IncludeWokenThreadIdsForWakers = opts.includeWokenThreadIdsForWakers;
         profileOpts.SplitChromeProcesses = opts.splitChromeProcesses;
         profileOpts.PprofComment = opts.pprofComment;
         profileOpts.Tabbed = opts.printTabbed;


### PR DESCRIPTION
Adds new command-line flag called `--includeWokenThreadIdsForWakers`.

When enabled, new labels will be added on the waker side and the new label will contain the thread ID of the thread which is woken up.

All labels are prefixed by a `[!]` marker.